### PR TITLE
Remove nwjs option and use only web

### DIFF
--- a/hxml/base.hxml
+++ b/hxml/base.hxml
@@ -6,10 +6,6 @@
 
 -main Main
 
-#if nwjs
---cmd haxe --run tasks.Build --web
-#end
-
 #if desktop-sdl
 --cmd haxe --run tasks.Build --desktop
 

--- a/tasks/Build.hx
+++ b/tasks/Build.hx
@@ -30,13 +30,6 @@ class Build {
 
       if (args.contains('--web')) {
         buildWeb(config, htmlBuildDir);
-        if (FileSystem.exists('${htmlBuildDir}/package.json')) {
-          FileSystem.deleteFile('${htmlBuildDir}/package.json');
-        }
-      }
-
-      if (args.contains('--nwjs')) {
-        buildWeb(config, htmlBuildDir);
         buildPackageJson(config, htmlBuildDir);
       }
     } catch (error) {


### PR DESCRIPTION
This removes the nwjs option as its not required since all debugging is done with the nwjs client and it works interchangeably with a regular web browser.