### PR TITLE
Refactor sprite key events

### DIFF
--- a/src/core/Sprite.hx
+++ b/src/core/Sprite.hx
@@ -1,6 +1,5 @@
 package core;
 
-import hxd.Window;
 import hxd.Event;
 import h2d.Interactive;
 import h2d.Object;
@@ -27,7 +26,6 @@ class Sprite extends Object {
       interaction.onOver = onOver;
       interaction.onOut = onOut;
     }
-    Window.getInstance().addEventTarget(onEvent);
   }
 
   public function set_bitmap(bitmap: Bitmap) {
@@ -45,23 +43,9 @@ class Sprite extends Object {
     return this.tile;
   }
 
-  private function onEvent(event: Event) {
-    switch (event.kind) {
-      case EKeyDown:
-        onKeyDown(event);
-      case EKeyUp:
-        onKeyUp(event);
-      case _:
-    }
-  }
-
   public function onClick(event: Event) {}
 
   public function onOver(event: Event) {}
 
   public function onOut(event: Event) {}
-
-  public function onKeyUp(event: Event) {}
-
-  public function onKeyDown(event: Event) {}
 }

--- a/src/entities/Player.hx
+++ b/src/entities/Player.hx
@@ -1,34 +1,33 @@
 package entities;
 
-import hxd.Key;
 import h2d.RenderContext;
+import hxd.Key;
 import core.Sprite;
 import h2d.Tile;
 
 class Player extends Sprite {
   public var graphic: Tile;
-  public var speed: Int;
+  public var SPEED: Int = 5;
 
   public function new(x, y, ?parent) {
     graphic = Res.img.player.toTile();
     super(x, y, graphic, true, parent);
-
-    speed = 5;
   }
 
   public override function sync(ctx: RenderContext) {
     super.sync(ctx);
+    var tmod = hxd.Timer.tmod;
     if (Key.isDown(Key.W)) {
-      y -= speed;
+      y -= SPEED * tmod;
     }
     if (Key.isDown(Key.S)) {
-      y += speed;
+      y += SPEED * tmod;
     }
     if (Key.isDown(Key.A)) {
-      x -= speed;
+      x -= SPEED * tmod;
     }
     if (Key.isDown(Key.D)) {
-      x += speed;
+      x += SPEED * tmod;
     }
   }
 }

--- a/src/entities/Player.hx
+++ b/src/entities/Player.hx
@@ -1,7 +1,8 @@
 package entities;
 
+import hxd.Key;
+import h2d.RenderContext;
 import core.Sprite;
-import hxd.Event;
 import h2d.Tile;
 
 class Player extends Sprite {
@@ -15,21 +16,19 @@ class Player extends Sprite {
     speed = 5;
   }
 
-  public override function onKeyDown(event: Event) {
-    if (event.keyCode == 87 || event.keyCode == 38) {
-      this.y -= speed;
+  public override function sync(ctx: RenderContext) {
+    super.sync(ctx);
+    if (Key.isDown(Key.W)) {
+      y -= speed;
     }
-
-    if (event.keyCode == 83 || event.keyCode == 40) {
-      this.y += speed;
+    if (Key.isDown(Key.S)) {
+      y += speed;
     }
-
-    if (event.keyCode == 65 || event.keyCode == 37) {
-      this.x -= speed;
+    if (Key.isDown(Key.A)) {
+      x -= speed;
     }
-
-    if (event.keyCode == 68 || event.keyCode == 39) {
-      this.x += speed;
+    if (Key.isDown(Key.D)) {
+      x += speed;
     }
   }
 }


### PR DESCRIPTION
Refactors Sprite class to remove `onEvent` for `onKeyUp` and `onKeyDown` events, since most of the time key input is limited to the player sprite and none else.